### PR TITLE
LLMBenchmark: hermetic environment for reproducible results

### DIFF
--- a/Benchmarks/LLMBenchmark.py
+++ b/Benchmarks/LLMBenchmark.py
@@ -149,12 +149,23 @@ class LLMBenchmark:
 
                         # Build Engines
                         print(f"Building Engine for {model_name} , TP size:{tp_size}")
+                        # From https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/performance/perf-overview.md#engine-building
+                        # https://techcommunity.microsoft.com/t5/azure-high-performance-computing/optimizing-language-model-inference-on-azure/ba-p/4248271
+                        # --max_seq_len = (max_input + max_output) in our case it is 1024 + 128
+                        # From
+                        # https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/llama#long-context-evaluation
+                        # https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/performance/perf-best-practices.md
+                        # --max_num_tokens = (max_batch_size * max_input_len), in our case it is 1024*1024 => 1M
                         if "405" not in model_name:
                             build_engine_command = f'''
                                 trtllm-build \
                                 --checkpoint_dir {self.dir_path}/checkpoints/{model_name}/tp_{tp_size}/{self.precision}\
                                 --output_dir {self.dir_path}/engines/{model_name}/tp_{tp_size}/{self.precision} \
                                 --workers {tp_size} \
+                                --max_batch_size 1024 \
+                                --max_num_tokens 1048576 \
+                                --max_input_len  1048576 \
+                                --max_seq_len    1152 \
                                 --gemm_plugin auto
                             '''
                         else:
@@ -162,9 +173,10 @@ class LLMBenchmark:
                                 trtllm-build \
                                 --checkpoint_dir {self.dir_path}/checkpoints/{model_name}/tp_{tp_size}/{self.precision}\
                                 --output_dir {self.dir_path}/engines/{model_name}/tp_{tp_size}/{self.precision} \
-                                --max_num_tokens 8192 \
-                                --max_input_len 133000 \
-                                --max_seq_len  133000\
+                                --max_batch_size 256 \
+                                --max_num_tokens 262144 \
+                                --max_input_len  262144 \
+                                --max_seq_len    1152 \
                                 --use_paged_context_fmha enable \
                                 --workers 8
                             '''

--- a/Benchmarks/LLMBenchmark.py
+++ b/Benchmarks/LLMBenchmark.py
@@ -185,8 +185,12 @@ class LLMBenchmark:
                 for tp_size in self.config['models'][model_name]['tp_sizes']:
                     for batch_size in self.config['models'][model_name]['batch_sizes']:
                         for input_output_size in  self.config['models'][model_name]['input_output_sizes']:
+                            model_precision = self.config['models'][model_name]['precision']
                             warmup = self.config['models'][model_name]['warmup']
                             number_of_runs = self.config['models'][model_name]['number_of_runs']
+                            if model_precision == "fp8":
+                                model_precision = "float16"
+
                             print(f"Benchmarking {model_name} | TP Size: {tp_size} | Batch Size: {batch_size} | Input Size: {input_output_size.split(',')[0]} | Output Size: {input_output_size.split(',')[1]}")
 
                             if tp_size == 1:
@@ -207,7 +211,7 @@ class LLMBenchmark:
                                     mpirun -n {tp_size} --bind-to none -display-map --allow-run-as-root 
                                                 pipenv run python3 /workspace/TensorRT-LLM/benchmarks/python/benchmark.py \
                                                 --batch_size {batch_size} \
-                                                --dtype float16
+                                                --dtype {model_precision}
                                                 --input_output_len {input_output_size} \
                                                 --warm_up {warmup} \
                                                 --num_runs {number_of_runs} \

--- a/Benchmarks/LLMBenchmark.py
+++ b/Benchmarks/LLMBenchmark.py
@@ -34,11 +34,13 @@ class LLMBenchmark:
 
         # Define the Docker run options
         docker_run_options = {
+            'name': 'llm-benchmark',
             'runtime': 'nvidia',
             'volumes': {str(self.dir_path): {'bind': str(self.dir_path), 'mode': 'rw'}},
             'entrypoint': '/bin/bash',
             'tty': True,
-            'detach': True
+            'detach': True,
+            'auto_remove': True
         }
 
         #if existing container exists
@@ -58,6 +60,9 @@ class LLMBenchmark:
         if not os.path.exists(f'{self.dir_path}/checkpoints'):
             self.container.exec_run(f"mkdir {self.dir_path}/checkpoints")
 
+    def cleanup_container(self):
+        if self.container:
+            self.container.stop()
 
     def install_requirements(self):
         # Update package lists first

--- a/Benchmarks/LLMBenchmark.py
+++ b/Benchmarks/LLMBenchmark.py
@@ -240,7 +240,8 @@ class LLMBenchmark:
                                 '''
                             else:
                                 run_benchmark_command = f'''
-                                    mpirun -n {tp_size} --allow-run-as-root python3 {self.dir_path}/TensorRT-LLM/benchmarks/python/benchmark.py \
+                                    mpirun -n {tp_size} --bind-to none -display-map --allow-run-as-root \
+                                                python3 {self.dir_path}/TensorRT-LLM/benchmarks/python/benchmark.py \
                                                 --batch_size {batch_size} \
                                                 --dtype float16
                                                 --input_output_len {input_output_size} \

--- a/Benchmarks/TensorRT-LLM-img/Dockerfile
+++ b/Benchmarks/TensorRT-LLM-img/Dockerfile
@@ -20,7 +20,7 @@ RUN  apt-get update -y && \
        /usr/share/man /usr/share/locale /usr/share/zoneinfo
 
 # Install TensorRT-LLM repo
-ARG TENSORT_RT_COMMIT=a681853d3803ee5893307e812530b5e7004bb6e1
+ARG TENSORT_RT_COMMIT=b0880169d0fb8cd0363049d91aa548e58a41be07 # tag=0.14.0
 RUN mkdir /workspace && \
      git clone https://github.com/NVIDIA/TensorRT-LLM.git /workspace/TensorRT-LLM  && \
      cd /workspace/TensorRT-LLM && \

--- a/Benchmarks/TensorRT-LLM-img/Dockerfile
+++ b/Benchmarks/TensorRT-LLM-img/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1
+
+ARG IMAGE_BASE=nvidia/cuda:12.1.0-devel-ubuntu22.04
+FROM ${IMAGE_BASE}
+
+ARG BDIR=/tmp/bld
+ARG PYTHON_VER=3.10
+
+# Install common deps
+RUN  apt-get update -y && \
+     DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            python${PYTHON_VER} \
+	    python3-pip \
+	    openmpi-bin libopenmpi-dev git \
+	    git-lfs && \
+	    python3 -m pip install pipenv && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* \
+       /usr/share/doc /usr/share/doc-base \
+       /usr/share/man /usr/share/locale /usr/share/zoneinfo
+
+# Install TensorRT-LLM repo
+ARG TENSORT_RT_COMMIT=a681853d3803ee5893307e812530b5e7004bb6e1
+RUN mkdir /workspace && \
+     git clone https://github.com/NVIDIA/TensorRT-LLM.git /workspace/TensorRT-LLM  && \
+     cd /workspace/TensorRT-LLM && \
+     git reset --hard $TENSORT_RT_COMMIT
+COPY setup_model_env.sh /workspace/TensorRT-LLM/
+
+# Install dependencies for each model to separate directory to prevent conflicts
+ARG MODEL_LIST="llama"
+# Install dependencies for each model to pipenv directory to prevent conflicts
+# Pipenv usage example:
+# cd env/llama; pipenv run python3 -c "import torch; print(torch.__version__)"
+RUN cd  /workspace/TensorRT-LLM && \
+    ./setup_model_env.sh "${MODEL_LIST}"
+
+ENV PIPENV_VENV_IN_PROJECT=1
+WORKDIR  /workspace/TensorRT-LLM
+LABEL org.opencontainers.image.authors="monakhov@amazon.com"

--- a/Benchmarks/TensorRT-LLM-img/Makefile
+++ b/Benchmarks/TensorRT-LLM-img/Makefile
@@ -1,0 +1,28 @@
+IMAGE_BASE_NAME ?= cuda
+IMAGE_NAME ?= tensorrt-llm
+IMAGE_BASE_REPO=nvidia/
+IMAGE_BASE_TAG  ?= 12.4.0-devel-ubuntu22.04
+MODEL_LIST ?= "llama"
+TAG =${IMAGE_BASE_TAG}
+
+# podman:// or dockerd://
+CT_RUNTIME ?= dockerd://
+EXPORT_PATH ?= ..
+ZSTD_COMPRESS_OPTIONS ?= --ultra -22
+
+
+fetch:
+	docker pull "${IMAGE_BASE_REPO}${IMAGE_BASE_NAME}:${IMAGE_BASE_TAG}"
+
+build:
+	docker build --network=host --progress plain --rm \
+		--tag "${IMAGE_NAME}:${TAG}" \
+		--build-arg IMAGE_BASE="${IMAGE_BASE_REPO}${IMAGE_BASE_NAME}:${IMAGE_BASE_TAG}" \
+		--build-arg  MODEL_LIST="${MODEL_LIST}" \
+		-f Dockerfile .
+
+tar-img:
+	docker save \
+		"${IMAGE_BASE_REPO}${IMAGE_BASE_NAME}:${IMAGE_BASE_TAG}" \
+		"${IMAGE_NAME}:${TAG}" | \
+		zstdmt ${ZSTD_COMPRESS_OPTIONS} -v -f -o ${EXPORT_PATH}/${IMAGE_NAME}-${TAG}.tar.zst

--- a/Benchmarks/TensorRT-LLM-img/setup_model_env.sh
+++ b/Benchmarks/TensorRT-LLM-img/setup_model_env.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Install dependencies for each model to pipenv directory to prevent conflicts
+# Once environments are initialized it can be used like follows
+# cd /workspace/TensorRT-LLM/env/llama; pipenv run python3 -c "import torch; print(torch.__version__)"
+set -xeuo pipefail
+
+: "${MODEL_LIST:="llama phi"}"
+: "${PYTHON_VERSION:=3.10}"
+export PIPENV_VENV_IN_PROJECT=1
+
+for MODEL in $MODEL_LIST
+do
+    echo $MODEL
+    MODEL_HOME=/workspace/TensorRT-LLM/env/$MODEL
+    mkdir -p $MODEL_HOME
+    cd $MODEL_HOME
+    # Install packages
+    cp /workspace/TensorRT-LLM/examples/${MODEL}/requirements.txt .
+    pipenv install --verbose --python $PYTHON_VERSION -r requirements.txt
+    # Add library path to nvidia's libraries
+    echo "export LD_LIBRARY_PATH=:\$VIRTUAL_ENV/lib/python${PYTHON_VERSION}/site-packages/nvidia/nvjitlink/lib:\$LD_LIBRARY_PATH" >> .env
+    # Check environment
+    #pipenv run python3 -c 'import tensorrt_llm'
+done

--- a/README.md
+++ b/README.md
@@ -34,7 +34,16 @@ To assess how different system components (as tested by the microbenchmarks) aff
 
 ### Requirements
 All the requirements for the benchmarks can be intalled with a simple command: `bash install_requirements.sh`. This will install the Python PIP, NCCL, and Docker packages needed. 
+#### Build LLMBench container
+```
+#Build image from scratch
+make -C Benchmarks/TensorRT-LLM-img fetch build
+# Create image's tar archive, will be saved to Benchmark/tensorrt-llm-12.4.0-devel-ubuntu22.04.tar.zst
+make -C Benchmarks/TensorRT-LLM-img fetch build tar-img
+# Load container image from saved archive
+zstdcat tensorrt-llm-12.4.0-devel-ubuntu22.04.tar.zst | docker load
 
+```
 ### Runs
 The Azure AI Benchmarking Guide runs all the benchmarks described above with the command: `python3 runner.py`. The file [`config.json`](https://github.com/Azure/AI-benchmarking-guide/blob/main/config.json) contains the specific settings for the benchmarks.
 To run specific microbenchmarks, see  [`runner.py`](https://github.com/Azure/AI-benchmarking-guide/blob/02d2875b8051d357bd5a871bee6fb7104b631908/runner.py#L104) and comment out the tests you are not interested in running. The [`models`](https://github.com/Azure/AI-benchmarking-guide/blob/02d2875b8051d357bd5a871bee6fb7104b631908/config.json#L52) field in `config.json` contains all the end-to-end models that can be benchmarked. To run benchmark for a specific model, set `use_model: true`. They are all set to `false` by default.

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -14,7 +14,7 @@ pip3 install --no-cache-dir flash-attn
 pip3 install --no-cache-dir docker
 pip3 install --no-cache-dir prettytable
 
-sudo apt install fio
+sudo apt install -y fio zstd
 
 sleep 4
 

--- a/runner.py
+++ b/runner.py
@@ -98,6 +98,7 @@ def run_LLMBenchmark():
     test.download_models()
     test.build_engines()
     test.run_benchmark()
+    test.cleanup_container()
 
 machine_name = get_system_specs()
 

--- a/runner.py
+++ b/runner.py
@@ -1,5 +1,6 @@
 import json
 import os
+import logging
 import subprocess
 from Benchmarks import GEMMCublasLt as gemm
 from Benchmarks import HBMBandwidth as HBM
@@ -13,6 +14,12 @@ from Benchmarks import LLMBenchmark as llmb
 machine_name = ""
 current = os.getcwd()
 tools.create_dir("Outputs")
+LOGLEVEL = os.environ.get('LOGLEVEL', 'INFO').upper()
+logging.basicConfig(filename="Outputs/runner.log",
+                    filemode='w',
+                    format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
+                    datefmt='%H:%M:%S',
+                    level=LOGLEVEL)
 
 
 def get_system_specs():


### PR DESCRIPTION
Currently LLMBenchmark runtime environment handling is far from optimal.
## Issues:
- Container created on each execution from scratch which makes it almost impossible to have reproducible results.
- Different model families has different package requirements which may conflict with each other.
- No debug logs from container_exec  which makes is hard to debug issues.

This patch set migrate to hermetic container image which build from deterministic Dockerfile.
- Migrate to Dockerfile
- Add container commands logging to Output/runner.log

## Bug fixes:
  - Meta-Llama-3.1-405B-FP8 use bfloat16, but benchmark.py executed with hardcoded float16 
  - llmbench: fix engines build parameters for larger batch_sizes
## Pefromance issues:
 - LLMBenchmark: Do not use MPI binding   (incorrect CPU pinning result in 1-2% degradation on Meta-Llama-3-70B)